### PR TITLE
feat: add copy component code button

### DIFF
--- a/components/github-md-view.js
+++ b/components/github-md-view.js
@@ -69,7 +69,7 @@ class MarkdownView extends HTMLElement {
    */
   async convertMarkdownToHtml(markdown) {
     await this._deps;
-    // @ts-expect-error Marked is fetched from the linked {@link DEPS}
+    /** @ts-expect-error Marked is fetched from the linked {@link MarkdownView.DEPS} */
     return marked.parse(markdown);
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,6 @@
     "outDir": "./built",
     "skipLibCheck": false,
     "strict": true,
-    "target": "es2016",
+    "target": "es2018",
   }
 }


### PR DESCRIPTION
Copy component code on button click

<img width="377" alt="Screenshot 2023-07-02 at 2 15 43 PM" src="https://github.com/iamogbz/oh-my-wcs/assets/2528959/073a96aa-27aa-405e-900f-f18d84702d07">

- [x] Change target to `es2018`
- [x] Uses new copy api
- [x] Fallback when unsupported
- [x] Visual indication of copy status