### PR TITLE
feat(github-file-view): add component to render single files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Oh My Web Components!
+# Oh My Web Components
 
 Floating web components for easy web building
 
@@ -12,4 +12,4 @@ Try out any component using the demo links below, set the component name via the
 
 * [`github-md-view`](?component-name=github-md-view&url=components/github-md-view.md): 👈🏾 demo
 * [`github-diff-view`](?component-name=github-md-view&url=components/github-diff-view.md): [demo](?component-name=github-diff-view&head=f1c3c32&base=9dfe892&repo=tophat/webext-training&file=package.json)
-* [`github-file-view`](?component-name=github-md-view&url=components/github-file-view.md): [demo](?component-name=github-file-view&ref=HEAD&repo=iamogbz/oh-my-wcs&file=components/github-file-view.js&lines=L10-L42)
+* [`github-file-view`](?component-name=github-md-view&url=components/github-file-view.md): [demo](?component-name=github-file-view&ref=HEAD&repo=iamogbz/oh-my-wcs&file=components/github-diff-view.js&lines=L10-L42)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Oh My Web Components
+# Oh My Web Components❗️
 
 Floating web components for easy web building
 

--- a/README.md
+++ b/README.md
@@ -12,3 +12,4 @@ Try out any component using the demo links below, set the component name via the
 
 * [`github-md-view`](?component-name=github-md-view&url=components/github-md-view.md): 👈🏾 demo
 * [`github-diff-view`](?component-name=github-md-view&url=components/github-diff-view.md): [demo](?component-name=github-diff-view&head=f1c3c32&base=9dfe892&repo=tophat/webext-training&file=package.json)
+* [`github-file-view`](?component-name=github-md-view&url=components/github-file-view.md): [demo](?component-name=github-file-view&ref=HEAD&repo=iamogbz/oh-my-wcs&file=components/github-file-view.js&lines=L10-L42)

--- a/components/github-diff-view.js
+++ b/components/github-diff-view.js
@@ -183,7 +183,7 @@ class DiffView extends HTMLElement {
   static DEPS = {
     // https://github.com/octokit/octokit.js#usage
     "https://esm.sh/octokit": { Octokit: "Octokit" },
-  }
+  };
   static RENDER = {
     CHANGEBAR_STOPS: 5,
     CLS_ICON_SET: "material-icons-round",
@@ -196,7 +196,7 @@ class DiffView extends HTMLElement {
     TOKEN_LINE_DEL: "-",
     TOKEN_LINE_NIL: "\\ No newline at end of file",
     TEXT_COPY_BTN: "filter_none",
-  }
+  };
 
   /* Required attributes */
   static ATTR_HEAD = "head";
@@ -213,8 +213,10 @@ class DiffView extends HTMLElement {
       Object.entries(DiffView.DEPS).map(async ([scriptUrl, shimImports]) => {
         const module = await import(scriptUrl);
         Object.entries(shimImports).forEach(([sourceKey, targetValue]) => {
-          Object.defineProperty(window, targetValue, { value: module[sourceKey] })
-        })
+          Object.defineProperty(window, targetValue, {
+            value: module[sourceKey],
+          });
+        });
       })
     );
   }
@@ -222,20 +224,27 @@ class DiffView extends HTMLElement {
   get params() {
     const urlParams = new URLSearchParams(window.location.search);
     const attrParams = {
-      auth: this.getAttribute(DiffView.ATTR_AUTH) ?? urlParams.get(DiffView.ATTR_AUTH),
-      repo: this.getAttribute(DiffView.ATTR_REPO) ??
+      auth:
+        this.getAttribute(DiffView.ATTR_AUTH) ??
+        urlParams.get(DiffView.ATTR_AUTH) ??
+        undefined,
+      repo:
+        this.getAttribute(DiffView.ATTR_REPO) ??
         urlParams.get(DiffView.ATTR_REPO),
-      file: this.getAttribute(DiffView.ATTR_FILE) ??
+      file:
+        this.getAttribute(DiffView.ATTR_FILE) ??
         urlParams.get(DiffView.ATTR_FILE),
-      head: this.getAttribute(DiffView.ATTR_HEAD) ??
+      head:
+        this.getAttribute(DiffView.ATTR_HEAD) ??
         urlParams.get(DiffView.ATTR_HEAD),
-      base: this.getAttribute(DiffView.ATTR_BASE) ??
+      base:
+        this.getAttribute(DiffView.ATTR_BASE) ??
         urlParams.get(DiffView.ATTR_BASE),
-    }
+    };
     return {
       ...attrParams,
-      compareUrlPath: `${attrParams.repo}/compare/${attrParams.head}...${attrParams.base}`
-    }
+      compareUrlPath: `${attrParams.repo}/compare/${attrParams.head}...${attrParams.base}`,
+    };
   }
 
   connectedCallback() {
@@ -266,19 +275,25 @@ class DiffView extends HTMLElement {
 
     await this._deps;
     /** @ts-expect-error Octokit is fetched from the linked {@link DiffView.DEPS} */
-    const octokit = new Octokit({ auth })
-    octokit.request(`GET ${diffApiUrl}`)
-      .then((/** @type {{ data: { files: { filename: string; patch: string }[]; }}} */ { data }) => {
-        const diffPatch = data.files.filter(
-          (f) => f.filename === file
-        )[0]?.patch;
-        if (file && diffPatch) {
-          this.innerHTML = DIFF_RENDER_STYLES; // clear existing diff
-          this.appendChild(this.convertDiffToHtml(file, diffPatch));
-        } else {
-          throw `Missing '${file}' diff: ${diffApiUrl}`;
+    const octokit = new Octokit({ auth });
+    octokit
+      .request(`GET ${diffApiUrl}`)
+      .then(
+        (
+          /** @type {{ data: { files: { filename: string; patch: string }[]; }}} */ {
+            data,
+          }
+        ) => {
+          const diffPatch = data.files.filter((f) => f.filename === file)[0]
+            ?.patch;
+          if (file && diffPatch) {
+            this.innerHTML = DIFF_RENDER_STYLES; // clear existing diff
+            this.appendChild(this.convertDiffToHtml(file, diffPatch));
+          } else {
+            throw `Missing '${file}' diff: ${diffApiUrl}`;
+          }
         }
-      })
+      )
       .catch((/** @type {Error} */ error) => {
         console.error(error);
         this.innerHTML = `<p>Error loading diff</p>`;
@@ -316,7 +331,7 @@ class DiffView extends HTMLElement {
       return this.createDiffLine(line, lineNumBase, lineNumHead);
     });
     // prepend code summary diff line
-    lineDiffRenders.unshift(this.createDiffLine(summary))
+    lineDiffRenders.unshift(this.createDiffLine(summary));
 
     // view header elems
     const lineCountDiff = lineCountBase + lineCountHead;
@@ -324,7 +339,7 @@ class DiffView extends HTMLElement {
     const changeStopScale = DiffView.RENDER.CHANGEBAR_STOPS / lineCountTotal;
     const changeSummaryCountDel = Math.round(changeStopScale * lineCountBase);
     const changeSummaryCountAdd = Math.round(changeStopScale * lineCountHead);
-    const compareLink = `https://github.com/${this.params.compareUrlPath}/#${filename}`
+    const compareLink = `https://github.com/${this.params.compareUrlPath}/#${filename}`;
     const headerElems = [
       `<div class="diff-header">`,
       `<span class="diff-summary-count">${lineCountDiff}</span>`,
@@ -332,11 +347,12 @@ class DiffView extends HTMLElement {
       ...Array(DiffView.RENDER.CHANGEBAR_STOPS)
         .fill(null)
         .map((_, i) => {
-          return `<span class="${DiffView.RENDER.CLS_ICON_SET} change-bar-stop-${i} ${i < changeSummaryCountAdd
-            ? DiffView.RENDER.CLS_LINE_ADD
-            : i - changeSummaryCountAdd < changeSummaryCountDel
-              ? DiffView.RENDER.CLS_LINE_DEL
-              : DiffView.RENDER.CLS_LINE_NIL
+          return `<span class="${DiffView.RENDER.CLS_ICON_SET
+            } change-bar-stop-${i} ${i < changeSummaryCountAdd
+              ? DiffView.RENDER.CLS_LINE_ADD
+              : i - changeSummaryCountAdd < changeSummaryCountDel
+                ? DiffView.RENDER.CLS_LINE_DEL
+                : DiffView.RENDER.CLS_LINE_NIL
             }">square</span>`;
         }),
       `</span>`,
@@ -350,7 +366,9 @@ class DiffView extends HTMLElement {
     diffHtml.className = "change-diff";
     diffHtml.innerHTML = [...headerElems, ...lineDiffRenders].join("");
 
-    this.setupCopyButton(diffHtml.querySelector(`.${DiffView.RENDER.CLS_COPY_BTN}`));
+    this.setupCopyButton(
+      diffHtml.querySelector(`.${DiffView.RENDER.CLS_COPY_BTN}`)
+    );
 
     return diffHtml;
   }
@@ -373,7 +391,11 @@ class DiffView extends HTMLElement {
     // use native inner text escape to handle possible html code insertion
     const codeContainer = document.createElement("pre");
     codeContainer.className = "code-line";
-    if (isEmptyLine) codeContainer.classList.add(DiffView.RENDER.CLS_ICON_SET, DiffView.RENDER.TOKEN_LINE_NIL);
+    if (isEmptyLine)
+      codeContainer.classList.add(
+        DiffView.RENDER.CLS_ICON_SET,
+        DiffView.RENDER.TOKEN_LINE_NIL
+      );
     codeContainer.innerText =
       (isEmptyLine && "remove_circle_outline") ||
       lineContent.replace(/(.)/, (s) => `${s} `);
@@ -381,10 +403,8 @@ class DiffView extends HTMLElement {
     return `
 <div class="diff-line ${lineClass}" tabindex="0">
   <span class="diff-line-num">
-      <span class="line-num-base">${(!isEmptyLine && lineNumBase) || ""
-      }</span>
-      <span class="line-num-head">${(!isEmptyLine && lineNumHead) || ""
-      }</span>
+      <span class="line-num-base">${(!isEmptyLine && lineNumBase) || ""}</span>
+      <span class="line-num-head">${(!isEmptyLine && lineNumHead) || ""}</span>
   </span>
   ${codeContainer.outerHTML}
 </div>

--- a/components/github-diff-view.js
+++ b/components/github-diff-view.js
@@ -356,7 +356,7 @@ class DiffView extends HTMLElement {
             }">square</span>`;
         }),
       `</span>`,
-      `<a class="diff-filename" tabindex="0" href=${compareLink} target="_blank">${filename}</a>`,
+      `<a class="diff-filename" title="Open in github comparison" tabindex="0" href=${compareLink} target="_blank">${filename}</a>`,
       `<span class="${DiffView.RENDER.CLS_COPY_BTN} ${DiffView.RENDER.CLS_ICON_SET}" title="Copy component code">${DiffView.RENDER.TEXT_COPY_BTN}</span>`,
       `</div>`,
     ];
@@ -394,7 +394,7 @@ class DiffView extends HTMLElement {
     if (isEmptyLine)
       codeContainer.classList.add(
         DiffView.RENDER.CLS_ICON_SET,
-        DiffView.RENDER.TOKEN_LINE_NIL
+        DiffView.RENDER.CLS_LINE_NIL
       );
     codeContainer.innerText =
       (isEmptyLine && "remove_circle_outline") ||

--- a/components/github-diff-view.js
+++ b/components/github-diff-view.js
@@ -240,7 +240,8 @@ class DiffView extends HTMLElement {
 
   connectedCallback() {
     let hasRequiredAttributes = true;
-    const { auth: _, ...requiredAttrs } = this.params;
+    const { ...requiredAttrs } = this.params;
+    delete requiredAttrs.auth;
     const component = document.createElement(DiffView.NAME);
     Object.entries(requiredAttrs).forEach(([key, value]) => {
       if (!value) return (hasRequiredAttributes = false);

--- a/components/github-diff-view.js
+++ b/components/github-diff-view.js
@@ -347,13 +347,15 @@ class DiffView extends HTMLElement {
       ...Array(DiffView.RENDER.CHANGEBAR_STOPS)
         .fill(null)
         .map((_, i) => {
-          return `<span class="${DiffView.RENDER.CLS_ICON_SET
-            } change-bar-stop-${i} ${i < changeSummaryCountAdd
+          return `<span class="${
+            DiffView.RENDER.CLS_ICON_SET
+          } change-bar-stop-${i} ${
+            i < changeSummaryCountAdd
               ? DiffView.RENDER.CLS_LINE_ADD
               : i - changeSummaryCountAdd < changeSummaryCountDel
-                ? DiffView.RENDER.CLS_LINE_DEL
-                : DiffView.RENDER.CLS_LINE_NIL
-            }">square</span>`;
+              ? DiffView.RENDER.CLS_LINE_DEL
+              : DiffView.RENDER.CLS_LINE_NIL
+          }">square</span>`;
         }),
       `</span>`,
       `<a class="diff-filename" title="Open in github comparison" tabindex="0" href=${compareLink} target="_blank">${filename}</a>`,
@@ -385,8 +387,8 @@ class DiffView extends HTMLElement {
           ? DiffView.RENDER.CLS_LINE_NIL
           : DiffView.RENDER.CLS_LINE_SUM
         : lineNumBase
-          ? DiffView.RENDER.CLS_LINE_DEL
-          : DiffView.RENDER.CLS_LINE_ADD;
+        ? DiffView.RENDER.CLS_LINE_DEL
+        : DiffView.RENDER.CLS_LINE_ADD;
 
     // use native inner text escape to handle possible html code insertion
     const codeContainer = document.createElement("pre");

--- a/components/github-file-view.js
+++ b/components/github-file-view.js
@@ -1,0 +1,396 @@
+const FILE_RENDER_STYLES = `
+<link href="https://fonts.googleapis.com/css2?family=Material+Icons+Round" rel="stylesheet" />
+<style>
+.file-wrapper {
+    --color-border-subtle: #1f232826;
+    --color-bg-subtle: #f6f8fa;
+    --color-bg-default: #ffffff;
+    --color-fg-default: #1f2328;
+    --color-fg-active: #218bff;
+    --color-fg-muted: #656d76;
+    --color-file-add: #1f883d;
+    --color-file-del: #cf222e;
+
+    --size-padding-code: 4px;
+    --size-padding-default: 8px;
+    --size-padding-large: 24px;
+    --size-border-default: 1px;
+    --size-border-radius-container: 8px;
+    --size-file-line-num: 88px;
+    --size-file-line-height: 24px;
+
+    font-family: monospace;
+    font-size: 1em;
+    background: var(--color-bg-default);
+    color: var(--color-fg-default);
+    border-radius: var(--size-border-radius-container);
+    border: solid var(--size-border-default) var(--color-border-subtle);
+    overflow: hidden;
+
+    .file-header {
+        display: flex;
+        align-items: center;
+        justify-content: start;
+        padding: var(--size-padding-default) var(--size-padding-large);
+        gap: var(--size-padding-default);
+        background: var(--color-bg-subtle);
+        color: var(--color-fg-muted);
+        cursor: default;
+        border-bottom: solid var(--size-border-default) var(--color-border-subtle);
+
+        .material-icons-round {
+            font-size: 1em;
+            font-weight: 900;
+        }
+
+        .file-summary-count {
+            font-weight: 900;
+        }
+
+        .file-filename, .copy-filename {
+            color: var(--color-fg-default);
+            cursor: pointer;
+
+            &:hover {
+                color: var(--color-fg-active);
+            }
+        }
+
+        .file-filename {
+            padding: var(--size-padding-code);
+
+            &:hover {
+                text-decoration: underline;
+            }
+        }
+
+        .copy-filename {
+            opacity: 1;
+            transition: opacity 0.3s ease-in-out;
+        }
+    }
+
+    .file-line {
+        display: flex;
+        align-items: center;
+        justify-content: start;
+        min-height: var(--size-file-line-height);
+        max-height: var(--size-file-line-height);
+
+        &.file-line-del {
+            background: color-mix(in srgb, var(--color-file-del) 20%, transparent);
+        }
+
+        &.file-line-add {
+            background: color-mix(in srgb, var(--color-file-add) 20%, transparent);
+        }
+
+        &.file-line-sum {
+            background: color-mix(in srgb, var(--color-fg-active) 20%, transparent);
+        }
+
+        &:active, &:focus {
+            font-weight: 900;
+            outline: 0;
+
+            .file-line-nil {
+                font-weight: 900;
+            }
+        }
+
+        .code-line {
+            margin: 0;
+            font-size: 0.8em;
+            padding: var(--size-padding-code);
+            display: flex;
+            align-items: center;
+            justify-content: left;
+            height: var(--size-file-line-height);
+
+            &.file-line-nil {
+                color: var(--color-file-del);
+                font-size: 1.2em;
+            }
+        }
+
+        .file-line-num {
+            background: color-mix(in srgb, var(--color-bg-subtle) 50%, transparent);
+            padding: 0 var(--size-padding-code);
+            user-select: none;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: calc(var(--size-padding-code) / 2);
+            height: var(--size-file-line-height);
+            max-width: var(--size-file-line-num);
+            min-width: var(--size-file-line-num);
+
+            .line-num-base, .line-num-head {
+                display: flex;
+                max-width: calc(var(--size-file-line-num) / 2 - var(--size-padding-code) / 4);
+                min-width: calc(var(--size-file-line-num) / 2 - var(--size-padding-code) / 4);
+                text-overflow: ellipsis;
+                overflow: auto hidden;
+                padding: 0;
+                text-align: end;
+                justify-content: end;
+                align-items: center;
+            }
+        }
+    }
+}
+</style>
+`;
+
+// Define the web component
+class FileView extends HTMLElement {
+  static NAME = "github-file-view";
+  static DEPS = {
+    // https://github.com/octokit/octokit.js#usage
+    "https://esm.sh/octokit": { Octokit: "Octokit" },
+  }
+  static RENDER = {
+    CLS_ICON_SET: "material-icons-round",
+    CLS_COPY_BTN: "copy-filename",
+    CLS_LINE_ADD: "file-line-add",
+    CLS_LINE_DEL: "file-line-del",
+    CLS_LINE_NIL: "file-line-nil",
+    CLS_LINE_SUM: "file-line-sum",
+    TOKEN_LINE_ADD: "+",
+    TOKEN_LINE_DEL: "-",
+    TOKEN_LINE_NIL: "\\ No newline at end of file",
+    TEXT_COPY_BTN: "filter_none",
+  }
+
+  /* Required attributes */
+  static ATTR_REF = "ref";
+  static ATTR_LINES = "lines";
+  static ATTR_FILE = "file";
+  static ATTR_REPO = "repo";
+  /* Optional attributes */
+  /** Github auth token used when present */
+  static ATTR_AUTH = "auth";
+
+  constructor() {
+    super();
+    this._deps = Promise.all(
+      Object.entries(FileView.DEPS).map(async ([scriptUrl, shimImports]) => {
+        const module = await import(scriptUrl);
+        Object.entries(shimImports).forEach(([sourceKey, targetValue]) => {
+          Object.defineProperty(window, targetValue, { value: module[sourceKey] })
+        })
+      })
+    );
+  }
+
+  get params() {
+    const urlParams = new URLSearchParams(window.location.search);
+    const attrParams = {
+      auth: this.getAttribute(FileView.ATTR_AUTH) ?? urlParams.get(FileView.ATTR_AUTH),
+      repo: this.getAttribute(FileView.ATTR_REPO) ??
+        urlParams.get(FileView.ATTR_REPO),
+      ref: this.getAttribute(FileView.ATTR_REF) ??
+        urlParams.get(FileView.ATTR_REF),
+      file: this.getAttribute(FileView.ATTR_FILE) ??
+        urlParams.get(FileView.ATTR_FILE),
+      lines: this.getAttribute(FileView.ATTR_LINES) ??
+        urlParams.get(FileView.ATTR_LINES),
+    }
+    return {
+      ...attrParams,
+      // fileUrlPath: `${attrParams.repo}/blob/${attrParams.ref}/${attrParams.file}#${attrParams.lines ?? ''}`
+    }
+  }
+
+  connectedCallback() {
+    let hasRequiredAttributes = true;
+    const { auth: _, ...requiredAttrs } = this.params;
+    Object.values(requiredAttrs).forEach((value) => {
+      if (!value) return (hasRequiredAttributes = false);
+    });
+
+    if (hasRequiredAttributes) {
+      this.render();
+    } else {
+      const prettyJson = JSON.stringify(requiredAttrs, null, 2);
+      this.innerHTML = `<p>Missing some parameters</p><pre><code>${prettyJson}</code><pre>`;
+    }
+  }
+
+  /**
+   * Fetch and render the file
+   */
+  async render() {
+    const { auth, file, repo, ref, lines } = this.params;
+    const fileApiUrl = `https://api.github.com/repos/${repo}/contents/${file}?ref=${ref}`;
+
+    await this._deps;
+    /** @ts-expect-error Octokit is fetched from the linked {@link FileView.DEPS} */
+    const octokit = new Octokit({ auth })
+    octokit.request(`GET ${fileApiUrl}`)
+      .then((/** @type {{ data: Record<'content'|'name'|'path'|'html_url'|'type', string>}}} */ { data }) => {
+        if (data.type == 'file') {
+          this.innerHTML = FILE_RENDER_STYLES; // clear existing file
+          const [from, to] = lines?.split('-').map(l => Number(l.match(/L(d+)/)?.[1])) ?? [0, Number.POSITIVE_INFINITY];
+          this.appendChild(this.convertFileToHtml(data, { from, to }));
+        } else {
+          throw `No file found '${file}': ${fileApiUrl}`;
+        }
+      })
+      .catch((/** @type {Error} */ error) => {
+        console.error(error);
+        this.innerHTML = `<p>Error loading file</p>`;
+      });
+  }
+
+  /**
+   * Convert patch string to html elements that can be rendered.
+   * @param {Record<'content'|'name'|'path'|'html_url'|'type', string>} data file api response data
+   * @param {{ from: number, to: number }} lineNum start to end render
+   */
+  convertFileToHtml(data, lineNum) {
+    // patch lines
+    const fileContent = atob(data.content)
+    const fileLines = fileContent.split("\n");
+    const fileLinesVisible = fileLines.filter((_, i) => i + 1 >= lineNum.from && i < lineNum.to);
+    this._componentCode = fileLinesVisible.join("\n");
+    // code file line elements
+    const lineFileRenders = fileLinesVisible.map((line, i) => this.createFileLine(line, lineNum.from + i, lineNum.from + i));
+
+    const fileLinesVisibleCount = fileLinesVisible.length;
+    const fileLinesVisibleIncrement = Math.floor(fileLinesVisibleCount / 2);
+
+    // prepend more code above line
+    const fileLinesAboveStart = lineNum.from - Math.min(lineNum.from, fileLinesVisibleIncrement)
+    if (fileLinesAboveStart) {
+      const fileLinesAboveEnd = lineNum.from - 1;
+      lineFileRenders.unshift(this.createFileLine(`L${fileLinesAboveStart}-L${fileLinesAboveEnd}`, fileLinesAboveStart, fileLinesAboveEnd));
+    }
+    // append more code below line
+    const fileLinesBelowEnd = lineNum.to + Math.min(fileLines.length - lineNum.to, fileLinesVisibleIncrement)
+    if (fileLinesBelowEnd) {
+      const fileLinesBelowStart = lineNum.to + 1;
+      lineFileRenders.push(this.createFileLine(`L${fileLinesBelowStart}-L${fileLinesBelowEnd}`, fileLinesBelowStart, fileLinesBelowEnd));
+    }
+
+    // view header elems
+    const headerElems = [
+      `<div class="file-header">`,
+      `<span class="file-summary-count">${fileLines.length} total line${fileLines.length === 1 ? '' : 's'}</span>`,
+      `<a class="file-filename" tabindex="0" href=${data.html_url} target="_blank">${data.name}</a>`,
+      `<span class="${FileView.RENDER.CLS_COPY_BTN} ${FileView.RENDER.CLS_ICON_SET}" title="Copy file lines">${FileView.RENDER.TEXT_COPY_BTN}</span>`,
+      `</div>`,
+    ];
+
+    // wrapper elem
+    const diffHtml = document.createElement("div");
+    diffHtml.className = "file-wrapper";
+    diffHtml.innerHTML = [...headerElems, ...lineFileRenders].join("");
+
+    this.setupCopyButton(diffHtml.querySelector(`.${FileView.RENDER.CLS_COPY_BTN}`));
+
+    return diffHtml;
+  }
+
+  createFileLine(
+    /** @type {string} */ lineContent,
+    /** @type {number} */ lineNumBase = 0,
+    /** @type {number} */ lineNumHead = 0
+  ) {
+    const isEmptyLine = lineContent.startsWith(FileView.RENDER.TOKEN_LINE_NIL);
+    const lineClass =
+      Boolean(lineNumBase) === Boolean(lineNumHead)
+        ? lineNumBase
+          ? FileView.RENDER.CLS_LINE_NIL
+          : FileView.RENDER.CLS_LINE_SUM
+        : lineNumBase
+          ? FileView.RENDER.CLS_LINE_DEL
+          : FileView.RENDER.CLS_LINE_ADD;
+
+    // use native inner text escape to handle possible html code insertion
+    const codeContainer = document.createElement("pre");
+    codeContainer.className = "code-line";
+    if (isEmptyLine) codeContainer.classList.add(FileView.RENDER.CLS_ICON_SET, FileView.RENDER.TOKEN_LINE_NIL);
+    codeContainer.innerText =
+      (isEmptyLine && "remove_circle_outline") ||
+      lineContent.replace(/(.)/, (s) => `${s} `);
+
+    return `
+<div class="file-line ${lineClass}" tabindex="0">
+  <span class="file-line-num">
+      <span class="line-num-base">${(!isEmptyLine && lineNumBase) || ""
+      }</span>
+      <span class="line-num-head">${(!isEmptyLine && lineNumHead) || ""
+      }</span>
+  </span>
+  ${codeContainer.outerHTML}
+</div>
+`;
+  }
+
+  /**
+   * Copy component code to clipboard when element is clicked
+   * @param {HTMLElement | null} copyButton
+   * @returns
+   */
+  setupCopyButton(copyButton) {
+    if (!copyButton) return;
+
+    const copyButtonTextDefault = FileView.RENDER.TEXT_COPY_BTN;
+    const copyButtonTextSuccess = "done";
+    const copyButtonTextFailure = "close";
+
+    copyButton?.addEventListener("click", () => {
+      if (!this._componentCode)
+        throw `Component code missing: ${this._componentCode}`;
+
+      const setButtonText = (/** @type {string | null} */ buttonText) => {
+        copyButton.setAttribute("style", "opacity: 0"),
+          setTimeout(() => {
+            copyButton.textContent = buttonText;
+            copyButton.setAttribute("style", "opacity: 1");
+          }, 200);
+      };
+      const setButtonSuccess = () => setButtonText(copyButtonTextSuccess);
+      const setButtonFailure = (/** @type {unknown} */ e) => {
+        console.error(e);
+        setButtonText(copyButtonTextFailure);
+      };
+      const resetButtonText = () =>
+        setTimeout(() => setButtonText(copyButtonTextDefault), 700);
+
+      try {
+        if (navigator.clipboard?.writeText) {
+          navigator.clipboard
+            .writeText(this._componentCode)
+            .then(setButtonSuccess)
+            .catch(setButtonFailure)
+            .finally(resetButtonText);
+        } else {
+          // Fallback for browsers without Clipboard API support
+          const copyTextHolderId = "copy-text-holder";
+          const textarea =
+            Array.from(document.getElementsByTagName("textarea")).find(
+              (elem) => elem.id === copyTextHolderId
+            ) ?? document.createElement("textarea");
+          textarea.id = copyTextHolderId;
+          textarea.value = this._componentCode;
+          textarea.style.visibility = "invisible";
+          document.body.appendChild(textarea);
+          textarea.select();
+          document.execCommand("copy");
+          setButtonSuccess();
+          document.body.removeChild(textarea);
+        }
+      } catch (e) {
+        setButtonFailure(e);
+      } finally {
+        resetButtonText();
+      }
+    });
+  }
+}
+
+// Define the custom element
+customElements.define(FileView.NAME, FileView);

--- a/components/github-file-view.js
+++ b/components/github-file-view.js
@@ -205,7 +205,8 @@ class FileView extends HTMLElement {
 
   connectedCallback() {
     let hasRequiredAttributes = true;
-    const { auth: _, ...requiredAttrs } = this.params;
+    const { ...requiredAttrs } = this.params;
+    delete requiredAttrs.auth;
     Object.values(requiredAttrs).forEach((value) => {
       if (!value) return (hasRequiredAttributes = false);
     });

--- a/components/github-file-view.md
+++ b/components/github-file-view.md
@@ -1,0 +1,27 @@
+# Github File View
+
+Show the raw contents of a single text file with line numbers for easy embedding in other sites.
+
+## Parameters
+
+| Param            | Value                | Description              |
+| ---------------- | -------------------- | ------------------------ |
+| `component-name` | `"github-file-view"` | __CONSTANT__             |
+| `repo`           | `string`             | Github `user/repo`       |
+| `file`           | `string`             | Git file path            |
+| `ref`            | `string`             | Git <REF>                |
+| `lines`          | `string?`            | e.g. `L1-L20`            |
+| `auth`           | `string?`            | Github [token][gh-token] |
+
+## Example
+
+```js
+<script src="https://raw.githubusercontent.com/iamogbz/oh-my-wcs/main/components/github-file-view.js" />
+
+<github-file-view repo="iamogbz/portmanteaux" file="src/components/Portmanteaux/useWordList.ts" head="HEAD" auth="https://github.com/settings/tokens" />
+```
+
+__NOTE__: Any attributes not provided will fallback to url parameters of the same name.
+
+<!-- Links -->
+[gh-token]: https://github.com/settings/tokens

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
       }
     </style>
     <script src="components/github-diff-view.js"></script>
+    <script src="components/github-file-view.js"></script>
     <script src="components/github-md-view.js"></script>
   </head>
 

--- a/index.html
+++ b/index.html
@@ -3,6 +3,10 @@
   <head>
     <title>Oh My Web Components! | github/iamogbz</title>
     <link
+      rel="icon"
+      href="https://fonts.gstatic.com/s/i/short-term/release/materialsymbolsrounded/new_releases/default/48px.svg"
+    />
+    <link
       rel="stylesheet"
       href="https://necolas.github.io/normalize.css/latest/normalize.css"
     />


### PR DESCRIPTION
<img width="541" alt="Screenshot 2023-07-11 at 9 49 35 PM" src="https://github.com/iamogbz/oh-my-wcs/assets/2528959/4ce58a8f-a8ed-4567-9e52-316af55dc6a7">

* Copy button copies currently viewed code lines
* File name links to the same file lines in github
* Expanding opens up until the top or bottom of file
* Documentation and demo added to index readme
* Other miscellaneous improvements
